### PR TITLE
Force OpenGL 1.4

### DIFF
--- a/launcher.sh
+++ b/launcher.sh
@@ -3,5 +3,5 @@
 if grep -q org.freedesktop.Platform.GL.nvidia /.flatpak-info ; then
 	exec /app/lib/sweethome3d/SweetHome3D-Java3D-1_5_2 "$@"
 else
-	exec /app/lib/sweethome3d/SweetHome3D "$@"
+	MESA_GL_VERSION_OVERRIDE=1.4 exec /app/lib/sweethome3d/SweetHome3D "$@"
 fi


### PR DESCRIPTION
The version of JOGL shipped with Sweet Home 3D requires GL 1.2. GL 1.4
is a newer version of that.

Closes: #3