### PR TITLE
Use non-directed URL for Sourceforge source

### DIFF
--- a/com.sweethome3d.Sweethome3d.json
+++ b/com.sweethome3d.Sweethome3d.json
@@ -36,7 +36,7 @@
                         "x86_64"
                     ],
                     "sha256": "b7a0d6bd6fc225f4d575db4d762c362dc3756cc79110cb6d6a2152de78f71b0e",
-                    "url": "https://freefr.dl.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-6.5/SweetHome3D-6.5-linux-x64.tgz",
+                    "url": "https://downloads.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-6.5/SweetHome3D-6.5-linux-x64.tgz",
                     "dest": "SweetHome3D",
                     "x-checker-data": {
                         "type": "html",


### PR DESCRIPTION
So as to avoid flatpak-external-data-checker creating pull requests with
different mirrors as endpoints.

See https://github.com/flathub/flatpak-external-data-checker/issues/150