### PR TITLE
Fix flatpak-external-data-checker metadata

### DIFF
--- a/com.sweethome3d.Sweethome3d.json
+++ b/com.sweethome3d.Sweethome3d.json
@@ -40,8 +40,8 @@
                     "dest": "SweetHome3D",
                     "x-checker-data": {
                         "type": "html",
-                        "url": "http://www.sweethome3d.com/",
-                        "version-pattern": "<a href=\"history.jsp\">Version ([\\d\\.-]*)</a>",
+                        "url": "http://www.sweethome3d.com/history.jsp",
+                        "version-pattern": "</a>Version \n        ([\\d\\.-]*), ",
                         "url-template": "https://downloads.sourceforge.net/project/sweethome3d/SweetHome3D/SweetHome3D-$version/SweetHome3D-$version-linux-x64.tgz"
                     }
                 },


### PR DESCRIPTION
The front page of this software doesn't always mention the latest
version of the software, just the major versions. Update the metadata to
check the usually-updated history page instead.