### PR TITLE
Use 22.08 Runtime

### DIFF
--- a/com.sweethome3d.Sweethome3d.json
+++ b/com.sweethome3d.Sweethome3d.json
@@ -2,7 +2,7 @@
     "app-id": "com.sweethome3d.Sweethome3d",
     "default-branch": "stable",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "20.08",
+    "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "SweetHome3D",
     "finish-args": [


### PR DESCRIPTION
org.freedesktop.Platform 20.08 is no longer receiving fixes and security updates. The app builds and launches correctly using the 22.08 runtime.