### PR TITLE
Set resolutionScale property as GDK_SCALE to enable HiDPI

### DIFF
--- a/com.sweethome3d.Sweethome3d.json
+++ b/com.sweethome3d.Sweethome3d.json
@@ -20,6 +20,7 @@
                 "mkdir /app/lib/",
                 "cp -r ./SweetHome3D/ /app/lib/sweethome3d/",
                 "sed -i -e 's,-Xmx2g,-Xmx2g -Dsun.java2d.opengl=true,g' /app/lib/sweethome3d/SweetHome3D",
+                "find /app/lib/sweethome3d -type f -name 'SweetHome3D*' -exec sed -i -e 's,-Xmx2g,-Xmx2g -Dcom.eteks.sweethome3d.resolutionScale=${GDK_SCALE},g' {} +",
                 "mkdir -p /app/bin/",
                 "install -m755 launcher.sh /app/bin/SweetHome3D",
                 "install -Dm644 ./SweetHome3D/SweetHome3DIcon.png /app/share/icons/com.sweethome3d.Sweethome3d.png",


### PR DESCRIPTION
Sweet Home 3D has it's own property to enable HiDPI - `com.eteks.sweethome3d.resolutionScale`.

It can be set using the same method as `sun.java2d.opengl`.

`GDK_SCALE` environment variable is used to determine the desired value.
