### PR TITLE
Update runtime to 24.08

### DIFF
--- a/com.sweethome3d.Sweethome3d.json
+++ b/com.sweethome3d.Sweethome3d.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.sweethome3d.Sweethome3d",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "22.08",
+    "runtime-version": "24.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "SweetHome3D",
     "finish-args": [


### PR DESCRIPTION
The currently used runtime version 22.08 is end-of-life and should be updated. Using the newly released 24.08 works fine for me.